### PR TITLE
Fix shared reference data loss: update memo after BUILD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1 (unreleased)
 
-- nothing yet
+- Fix shared reference data loss: update memo after BUILD
 
 ## 1.2.0 (2026-02-10)
 


### PR DESCRIPTION
When the same non-Persistent Python object is referenced in two places in a pickle, BINPUT clones the stack top into memo before BUILD transforms it (e.g. Reduce → Instance). BINGET then returns the stale Reduce clone, losing instance state on the second occurrence.

After BUILD, scan memo for entries matching the old pre-BUILD value and replace them with the post-BUILD result. This mirrors CPython's pickle VM which uses object identity (shared references).


**In Plone I have the problem under the following circumstance:**

I have a `force login handler` register as `IBeforeTraverseEvent` hook:

```
    <subscriber
        handler=".force_login.handler"
        for="Products.CMFCore.interfaces.ISiteRoot
             zope.traversing.interfaces.IBeforeTraverseEvent"
        />
```


The handler runs:
```
event.request.post_traverse(...)
```

Which eventually might raise `Unauthorized` if a user is anoymous.
We have this to protect the site from any anonymous traffic. 

**This results in:**
The same object is referenced twice, once in `__before_traverse__` and once in `__before_publishing_traverse__`. 

I used Claude Opus 4.6 to fix the Rust code. I understand the problem, and I understand the fix, but I have no experience with Rust. 