### PR TITLE
fix: use timezone.utc instead of datetime.UTC for Python 3.10 compat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+- Fix Python 3.10 incompatibility in the test suite: replace the
+  Python 3.11+ `datetime.UTC` import with `timezone.utc` in
+  `tests/test_pg_json.py` and `tests/test_known_types.py` [#10]
+
 ## 1.6.1 (2026-02-27)
 
 - CRITICAL Linux!

--- a/tests/test_known_types.py
+++ b/tests/test_known_types.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from datetime import time
 from datetime import timedelta
 from datetime import timezone
-from datetime import UTC
 from decimal import Decimal
 
 import json
@@ -58,13 +57,13 @@ class TestDatetime:
         assert restored == dt
 
     def test_tz_stdlib_utc(self):
-        dt = datetime(2025, 1, 1, tzinfo=UTC)
+        dt = datetime(2025, 1, 1, tzinfo=timezone.utc)
         data = pickle.dumps(dt, protocol=3)
         result = json.loads(zodb_json_codec.pickle_to_json(data))
         assert result == {"@dt": "2025-01-01T00:00:00+00:00"}
 
     def test_roundtrip_tz_stdlib_utc(self):
-        dt = datetime(2025, 1, 1, tzinfo=UTC)
+        dt = datetime(2025, 1, 1, tzinfo=timezone.utc)
         data = pickle.dumps(dt, protocol=3)
         json_str = zodb_json_codec.pickle_to_json(data)
         restored = pickle.loads(zodb_json_codec.json_to_pickle(json_str))

--- a/tests/test_pg_json.py
+++ b/tests/test_pg_json.py
@@ -6,7 +6,7 @@ Verifies that the JSON string path produces identical output to the dict path.
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
-from datetime import UTC
+from datetime import timezone
 from decimal import Decimal
 from uuid import UUID
 
@@ -114,7 +114,7 @@ class TestPgJsonKnownTypes:
         assert actual == expected
 
     def test_datetime(self):
-        dt = datetime(2024, 6, 15, 12, 30, 45, tzinfo=UTC)
+        dt = datetime(2024, 6, 15, 12, 30, 45, tzinfo=timezone.utc)
         record = make_zodb_record("myapp", "Obj", {"created": dt})
         self._assert_match(record)
 
@@ -143,7 +143,7 @@ class TestPgJsonKnownTypes:
     def test_mixed_types(self):
         state = {
             "title": "Test",
-            "created": datetime(2024, 1, 1, tzinfo=UTC),
+            "created": datetime(2024, 1, 1, tzinfo=timezone.utc),
             "score": Decimal("3.14"),
             "tags": frozenset(["a", "b"]),
             "coords": (1.0, 2.0),


### PR DESCRIPTION
## Problem

CI is red on `main`: test collection fails on Python 3.10 because two test files import `datetime.UTC`, which was only added in Python 3.11. The package declares `requires-python = ">=3.10"` and ships the 3.10 classifier, so this is a genuine compatibility gap.

```
ImportError: cannot import name 'UTC' from 'datetime'
ERROR tests/test_known_types.py
ERROR tests/test_pg_json.py
!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!
```

Fixes #10.

## Fix

Keep the declared 3.10 support and replace `datetime.UTC` with `timezone.utc` (available since Python 3.2):

- `tests/test_pg_json.py` — import `timezone`, use `tzinfo=timezone.utc`
- `tests/test_known_types.py` — drop the redundant `UTC` import (file already imported `timezone`), use `tzinfo=timezone.utc`
- `CHANGES.md` — changelog entry

## Verification

All 80 tests in both affected files pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)